### PR TITLE
✨ Add Redirect Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This extension is a fork of the official [GitHub Actions Extension](https://gith
 - Icons updated to use codicons and the testing icon set, making them themable
 - Revamped logging, much more detailed as to what is going on
 
-
 ## Why a fork?
 I initially maintained a parallel fork and went to a lot of work to make upstream changes independent and very mergeable. After a year of the GitHub team completely ignoring me and other PRs, it is clear the extension is in security maintenance mode, with only package dependency bumps being added.
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
-import { retry } from "@octokit/plugin-retry"
-import { throttling } from "@octokit/plugin-throttling"
+// import { retry } from "@octokit/plugin-retry"
+// import { throttling } from "@octokit/plugin-throttling"
 import { Octokit } from "@octokit/rest"
 import { version } from "package.json"
 
@@ -7,9 +7,12 @@ import { conditionalRequest } from "~/api/conditionalRequests"
 import { getGitHubApiUri } from "~/configuration/configReader"
 import { createOctokitLogger } from "~/log"
 
+import { cacheRedirect } from "./handlePermanentRedirect"
+// import { rateLimitTelemetryPlugin } from "./rateLimitTelemetry";
+
 export const userAgent = `VS Code GitHub Actions (${version})`
 
-const GhaOctokit = Octokit.plugin(conditionalRequest, throttling, retry)
+const GhaOctokit = Octokit.plugin(cacheRedirect, conditionalRequest)
 export type GhaOctokit = InstanceType<typeof GhaOctokit>
 
 export function getClient(token: string) {
@@ -18,20 +21,23 @@ export function getClient(token: string) {
     log: createOctokitLogger(),
     userAgent: userAgent,
     baseUrl: getGitHubApiUri(),
-    throttle: {
-      onRateLimit: (retryAfter, options, octokit) => {
-        octokit.log.warn(`Request quota exhausted for request ${options.method} ${options.url}.`)
+    request: {
+      redirect: "manual"
+    }
+    // throttle: {
+    //   onRateLimit: (retryAfter, options, octokit) => {
+    //     octokit.log.warn(`Request quota exhausted for request ${options.method} ${options.url}.`)
 
-        if (options.request.retryCount === 0) {
-          octokit.log.info(`Retrying after ${retryAfter} seconds.`)
-          return true
-        }
-      },
-      onSecondaryRateLimit: (retryAfter, options, octokit) => {
-        octokit.log.warn(
-          `Abuse detected for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds.`,
-        )
-      },
-    },
+    //     if (options.request.retryCount === 0) {
+    //       octokit.log.info(`Retrying after ${retryAfter} seconds.`)
+    //       return true
+    //     }
+    //   },
+    //   onSecondaryRateLimit: (retryAfter, options, octokit) => {
+    //     octokit.log.warn(
+    //       `Abuse detected for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds.`,
+    //     )
+    //   },
+    // },
   })
 }

--- a/src/api/handlePermanentRedirect.ts
+++ b/src/api/handlePermanentRedirect.ts
@@ -1,0 +1,61 @@
+import { OctokitPlugin } from "@octokit/core/types"
+
+import { logTrace } from "~/log"
+
+// HTTP status code for permanent redirect
+const HTTP_PERMANENT_REDIRECT = 301
+
+// Map to store permanent redirects. Key is original URL, value is new URL
+const redirectCache = new Map<string, string>()
+
+/**
+ * Octokit plugin that caches 301 Moved Permanently redirects and automatically
+ * applies them to subsequent requests to the same URL. 301 redirects count against the REST API limit so we want to minimize them by caching the new location and transparently applying it to future requests.
+ *
+ * This plugin uses octokit.hook.wrap to intercept all requests and:
+ * 1. Checks if the current URL has a cached redirect before requesting
+ * 2. Applies cached redirects transparently
+ * 3. On 301 responses, caches the new location and retries the request
+ *
+ * @param octokit - The Octokit instance to wrap with redirect handling
+ *
+ * @link https://octokit.github.io/rest.js/v22/#plugins
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const cacheRedirect: OctokitPlugin = (octokit) => {
+  // hook into the request lifecycle
+  octokit.hook.wrap("request", async (request, options) => {
+    const repoCacheKey = [options.owner || undefined, options.repo || undefined, options.url].join("-")
+
+    const redirectCacheKey = [repoCacheKey, options.url].join("-")
+    const redirectCacheHit = redirectCache.get(redirectCacheKey)
+    if (redirectCacheHit) {
+      octokit.log.debug(`Redirect cache hit for ${options.url} → ${redirectCacheHit} [${redirectCacheKey}]`)
+      options.baseUrl = ""
+      options.url = redirectCacheHit
+    }
+
+    let response: any = await request(options)
+    if (response.status === HTTP_PERMANENT_REDIRECT) {
+      const locationHeader = response.headers["location"]
+
+      if (locationHeader) {
+        redirectCache.set(redirectCacheKey, locationHeader)
+        octokit.log.info(
+          `↩️ Permanent Redirect Detected and Cached: ${options.url} → ${locationHeader} [${redirectCacheKey}]`,
+        )
+        options.url = locationHeader
+        response = await request(options)
+      }
+    }
+    return response
+  })
+}
+
+/**
+ * Clears all cached redirects. Useful for testing or resetting state.
+ */
+export function clearRedirectCache(): void {
+  redirectCache.clear()
+  logTrace("🗑️ Redirect cache cleared")
+}


### PR DESCRIPTION
Caches redirects and proactively performs redirection to avoid 301 Redirect calls, which consume REST API calls excessively and unnecessarily