### PR TITLE
✨ Add integrated browser support for GitHub links

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-node = "22.22.0"
+node = "latest"
 pnpm = "latest"

--- a/package.json
+++ b/package.json
@@ -168,6 +168,12 @@
           "markdownDescription": "If this is set to true, use the auth provider for the GitHub Enterprise URL configured in `github-enterprise.uri`",
           "default": false,
           "scope": "window"
+        },
+        "github-actions.useIntegratedBrowser": {
+          "type": "boolean",
+          "description": "Open GitHub links in VS Code's integrated browser instead of your system browser",
+          "default": true,
+          "scope": "window"
         }
       }
     },

--- a/src/api/openUri.ts
+++ b/src/api/openUri.ts
@@ -1,0 +1,15 @@
+import * as vscode from "vscode"
+
+import { useIntegratedBrowser } from "~/configuration/configReader"
+
+export function openUri(uri: vscode.Uri) {
+  const openResultPromise = useIntegratedBrowser()
+    ? vscode.commands.executeCommand<boolean>("workbench.action.browser.open", uri.toString(true))
+    : vscode.env.openExternal(uri)
+
+  openResultPromise.then((openResult) => {
+    if (openResult === false) {
+      vscode.window.showErrorMessage(`Failed to open URL: ${uri.toString()}`)
+    }
+  })
+}

--- a/src/commands/openWorkflowRun.ts
+++ b/src/commands/openWorkflowRun.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode"
 
+import { openUri } from "~/api/openUri"
 import { WorkflowRunCommandArgs } from "~/treeViews/shared/workflowRunNode"
 
 export function registerOpenWorkflowRun(context: vscode.ExtensionContext) {
@@ -7,7 +8,7 @@ export function registerOpenWorkflowRun(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("github-actions.workflow.run.open", async (args: WorkflowRunCommandArgs) => {
       const run = args.run
       const url = run.html_url
-      await vscode.env.openExternal(vscode.Uri.parse(url))
+      openUri(vscode.Uri.parse(url))
     }),
   )
 }

--- a/src/commands/openWorkflowStepLogs.ts
+++ b/src/commands/openWorkflowStepLogs.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode"
 
+import { openUri } from "~/api/openUri"
 import { WorkflowStep } from "~/model"
 import { WorkflowStepNode } from "~/treeViews/shared/workflowStepNode"
 
@@ -18,7 +19,7 @@ export function registerOpenWorkflowStepLogs(context: vscode.ExtensionContext) {
         url = url + "#step:" + index.toString() + ":1"
       }
 
-      await vscode.env.openExternal(vscode.Uri.parse(url))
+      openUri(vscode.Uri.parse(url))
     }),
   )
 }

--- a/src/configuration/configReader.ts
+++ b/src/configuration/configReader.ts
@@ -24,6 +24,10 @@ export function useEnterprise(): boolean {
   return getConfiguration().get<boolean>(getSettingsKey("use-enterprise"), false)
 }
 
+export function useIntegratedBrowser(): boolean {
+  return getConfiguration().get<boolean>(getSettingsKey("useIntegratedBrowser"), true)
+}
+
 export function getGitHubApiUri(): string {
   if (!useEnterprise()) return DEFAULT_GITHUB_API
   const base = getConfiguration().get<string>("github-enterprise.uri", DEFAULT_GITHUB_API).replace(/\/$/, "")


### PR DESCRIPTION
Enable opening GitHub links in the VS Code integrated browser by default, with an option to revert to the external browser.